### PR TITLE
Fix mock time() function in tests

### DIFF
--- a/test/mocks/MockTime.h
+++ b/test/mocks/MockTime.h
@@ -60,7 +60,7 @@ inline unsigned long millis() {
 }
 
 // Mock time() function (standard C function)
-inline time_t time(time_t* t) {
+time_t time(time_t* t) {
     time_t current = MockTimeState::getTime();
     if (t != nullptr) {
         *t = current;


### PR DESCRIPTION
The prototype in the C library is:

```c
time_t time(time_t* arg);
```

And, at least with my compiler (macOS, so LLVM), that makes the difference between the test `test_mock_time_seconds` calling the C library version or the mock.